### PR TITLE
Adding the namespace flag for installing operator in non-default namespace

### DIFF
--- a/cmd/index/capabilities/command.go
+++ b/cmd/index/capabilities/command.go
@@ -71,6 +71,8 @@ func NewCmd() *cobra.Command {
 		"Name of Kubernetes Secret to use for pulling registry images")
 	cmd.Flags().StringVar(&flags.ServiceAccount, "service-account", "default",
 		"Name of Kubernetes Service Account to use")
+	cmd.Flags().StringVar(&flags.NameSpace, "namespace", "default",
+		"Name of Kubernetes Namespace to use")
 
 	return cmd
 }
@@ -110,7 +112,7 @@ func run(cmd *cobra.Command, args []string) error {
 	var Bundle models.AuditCapabilities
 
 	log.Info("Deploying operator with operator-sdk...")
-	operatorsdk := exec.Command("operator-sdk", "run", "bundle", flags.FilterBundle, "--pull-secret-name", flags.PullSecretName, "--timeout", "5m")
+	operatorsdk := exec.Command("operator-sdk", "run", "bundle", flags.FilterBundle, "--pull-secret-name", flags.PullSecretName, "--timeout", "5m", "--namespace", flags.NameSpace)
 	runCommand, err := pkg.RunCommand(operatorsdk)
 
 	if err != nil {

--- a/openshift/capabilities-tool-job.yaml
+++ b/openshift/capabilities-tool-job.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       containers:
       - name: capabilities-tool
-        image: quay.io/opdev/capabilities-tool:v0.2.7
-        args: ["index","capabilities","--container-engine","podman","--output-path","/opt/capabilities-tool","--bundle-image","$(bundle_image)","--bucket-name","$(bucket_name)","--bundle-name","$(bundle_name)"]
+        image: quay.io/opdev/capabilities-tool:v1.0.1-test
+        args: ["index","capabilities","--container-engine","podman","--output-path","/opt/capabilities-tool","--bundle-image","$(bundle_image)","--bucket-name","$(bucket_name)","--bundle-name","$(bundle_name)","--namespace","$(namespace)"]
         env:
           - name: bucket_name
             valueFrom:
@@ -40,6 +40,11 @@ spec:
               configMapKeyRef:
                 name: audit-env-var
                 key: bundle_name
+          - name: namespace
+            valueFrom:
+              configMapKeyRef:
+                name: audit-env-var
+                key: namespace
         securityContext:
           privileged: true
         volumeMounts:

--- a/pkg/reports/capabilities/flags.go
+++ b/pkg/reports/capabilities/flags.go
@@ -17,4 +17,5 @@ type BindFlags struct {
 	PullSecretName string `json:"pullSecretName"`
 	ServiceAccount string `json:"serviceAccount"`
 	PackageName    string `json:"packageName,omitempty"`
+	NameSpace      string `json:"nameSpace,omitempty"`
 }


### PR DESCRIPTION
Adding a `namespace` flag to be passed for installing the operator in a particular namespace(non-default).
If the Namespace flag is not specified, it will install the operator in the `default` namespace.

Signed-off-by: Yash Oza yoza@gmail.com